### PR TITLE
Release/1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to **pg-schemata** will be documented in this file.
 
 ---
 
-Latest commit: `7e04823`
+Latest commit: `a798d57`
+
+---
+
+## [v1.1.1] - 2025-09-26
+
+Schema builder now emits clearer logging and supports index generation across schemas, including new coverage for customers.
+
+### 🚀 Features
+
+- Enhance schema builder to surface index creation errors and ensure indexes are generated alongside table creation (`a798d57`)
+
+### 🧪 Tests
+
+- Refactor `schemaBuilder` test suite for readability and add assertions for index creation (`f43cf26`)
 
 ---
 

--- a/Examples/migration-tutorial/src/schemas/customersSchema.js
+++ b/Examples/migration-tutorial/src/schemas/customersSchema.js
@@ -11,5 +11,20 @@ export const customersSchema = {
   constraints: {
     primaryKey: ['id'],
     unique: [['email']],
+    indexes: [
+      // Simple index on phone for quick lookups
+      { columns: ['phone'] },
+      // Partial index for searching active customers by name
+      {
+        columns: ['full_name'],
+        where: 'deactivated_at IS NULL',
+      },
+      // Composite index for customer search with custom name
+      {
+        name: 'idx_customers_search',
+        columns: ['email', 'full_name'],
+        using: 'btree',
+      },
+    ],
   },
 };

--- a/design_docs/PR_Review_for_Dummies.md
+++ b/design_docs/PR_Review_for_Dummies.md
@@ -1,0 +1,36 @@
+# PR Release Guide (v1.1.1)
+
+## 1. Prep Workspace
+- `git checkout release/1.1.1` and confirm `git status` is clean.
+- Review `design_docs/RELEASE_CANDIDATE.md` and refresh the checklist.
+- Update `CHANGELOG.md` with the 1.1.1 entry (reflecting the release, not the RC).
+- Ensure `package.json` (and other version files) read `1.1.1` without the `-rc` suffix.
+
+## 2. Sanity Checks
+- Run automated tests (unit/integration/e2e as required).
+- Complete any manual validation steps listed in the release checklist.
+- Verify the code matches the RC build already published.
+
+## 3. Draft the PR
+- Push `release/1.1.1` and open a PR into `main`.
+- Summarize key changes (link to `CHANGELOG.md` entry).
+- Reference the release checklist and note that this promotes `v1.1.1-rc.1` to production.
+
+## 4. Self-Review & Approval
+- Walk the diff in the PR UI; confirm no unexpected files or merges.
+- Tick each release checklist item in `design_docs/RELEASE_CANDIDATE.md`.
+- Wait for CI to go green; fix any issues before approving.
+- Approve and merge the PR (merge commit or squash per convention).
+
+## 5. Release & Tag
+- Switch to `main`, pull latest, and run the production publish command (`npm publish --tag latest` or your final release command).
+- Create the `v1.1.1` git tag on the release commit and push tags.
+
+## 6. Back-Merge to Development
+- Check out your dev branch (e.g. `develop`), merge or fast-forward from `main`.
+- Push the updated dev branch so the released state is shared.
+- Mark the release checklist complete, noting the tag and artifacts.
+
+## 7. Post-Release Follow-up
+- Archive release notes in docs or project tracker.
+- Monitor telemetry/support channels for any issues.

--- a/design_docs/RELEASE_CANDIDATE.md
+++ b/design_docs/RELEASE_CANDIDATE.md
@@ -61,8 +61,9 @@ export TARGET_VERSION=1.1.0
 export RC_ITERATION=0
 export RC_NAME="v${TARGET_VERSION}-rc.${RC_ITERATION}"
 
-npm version preminor --preid=rc --no-git-tag-version    # Increment minor version
 npm version prerelease --preid=rc --no-git-tag-version  # Increment rc version
+npm version preminor --preid=rc --no-git-tag-version    # Increment minor version
+npm version prepatch --preid=rc --no-git-tag-version
 
 git add package.json package-lock.json
 git commit -m "chore: bump version to ${RC_NAME}"

--- a/design_docs/RELEASE_CANDIDATE.md
+++ b/design_docs/RELEASE_CANDIDATE.md
@@ -61,9 +61,10 @@ export TARGET_VERSION=1.1.0
 export RC_ITERATION=0
 export RC_NAME="v${TARGET_VERSION}-rc.${RC_ITERATION}"
 
-npm version prerelease --preid=rc --no-git-tag-version  # Increment rc version
+npm version premajor --preid=rc --no-git-tag-version    # Increment major version
 npm version preminor --preid=rc --no-git-tag-version    # Increment minor version
-npm version prepatch --preid=rc --no-git-tag-version
+npm version prepatch --preid=rc --no-git-tag-version    # Increment patch version
+npm version prerelease --preid=rc --no-git-tag-version  # Increment rc version
 
 git add package.json package-lock.json
 git commit -m "chore: bump version to ${RC_NAME}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pg-schemata",
-  "version": "1.1.0",
+  "version": "1.1.1-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pg-schemata",
-      "version": "1.1.0",
+      "version": "1.1.1-rc.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pg-schemata",
-  "version": "1.1.1-rc.0",
+  "version": "1.1.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pg-schemata",
-      "version": "1.1.1-rc.0",
+      "version": "1.1.1-rc.1",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-schemata",
-  "version": "1.1.0",
+  "version": "1.1.1-rc.0",
   "homepage": "https://silverstone-i.github.io/pg-schemata/",
   "description": "A lightweight Postgres-first ORM layer built on top of pg-promise",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-schemata",
-  "version": "1.1.1-rc.0",
+  "version": "1.1.1-rc.1",
   "homepage": "https://silverstone-i.github.io/pg-schemata/",
   "description": "A lightweight Postgres-first ORM layer built on top of pg-promise",
   "main": "src/index.js",

--- a/src/QueryModel.js
+++ b/src/QueryModel.js
@@ -235,7 +235,14 @@ class QueryModel {
           : null;
       return { rows, nextCursor };
     } catch (err) {
-      console.error('Error occurred while finding after cursor:', err);
+      const level = err instanceof DatabaseError ? 'error' : 'debug';
+      logMessage({
+        logger: this.logger,
+        level,
+        schema: this._schema.dbSchema,
+        table: this._schema.table,
+        message: `findAfterCursor failure: ${err.message}`,
+      });
       throw err;
     }
   }

--- a/src/TableModel.js
+++ b/src/TableModel.js
@@ -205,13 +205,9 @@ class TableModel extends QueryModel {
       RETURNING *
     `;
 
-    console.log('Executing upsert query:', query);
-
     try {
       return await this.db.one(query);
     } catch (err) {
-      console.log('Error executing upsert query:', err);
-
       this.handleDbError(err);
     }
   }
@@ -647,18 +643,20 @@ class TableModel extends QueryModel {
 
   /**
    * Creates the table using the current schema definition.
+   * Automatically creates any indexes defined in the schema constraints.
    * @returns {Promise<void>}
    */
   async createTable() {
+    const hasIndexes = this._schema.constraints?.indexes?.length > 0;
     logMessage({
       logger: this.logger,
       level: 'info',
       schema: this._schema.dbSchema,
       table: this._schema.table,
-      message: 'Creating table from schema',
+      message: hasIndexes ? 'Creating table with indexes from schema' : 'Creating table from schema',
     });
     try {
-      const query = createTableSQL(this._schema);
+      const query = createTableSQL(this._schema, this.logger);
       return await this.db.none(query);
     } catch (err) {
       this.handleDbError(err);


### PR DESCRIPTION
# This PR promotes `v1.1.1-rc.1` to production.

## [v1.1.1] - 2025-09-26

Schema builder now emits clearer logging and supports index generation across schemas, including new coverage for customers.

### 🚀 Features

- Enhance schema builder to surface index creation errors and ensure indexes are generated alongside table creation (`a798d57`)

### 🧪 Tests

- Refactor `schemaBuilder` test suite for readability and add assertions for index creation (`f43cf26`)
