### PR TITLE
Release v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to **pg-schemata** will be documented in this file.
 
 ---
 
-Latest commit: `bdc0054`
+Latest commit: `bd52f65`
+
+---
+
+## [v1.3.2] - 2026-05-07
+
+### 🐛 Fixes
+
+- **Cross-Schema Foreign Keys**: `createTableSQL` now honors a target schema on foreign key constraints
+  - Add optional `references.schema` to `ConstraintDefinition` for explicit cross-schema FK targets
+  - Bare `references.table` falls back to `references.schema` (or the owning schema if absent)
+  - Dotted `references.table` (e.g. `'admin.countries'`) still takes precedence when both forms are supplied
+
+### 🛠 Chores
+
+- **Dependencies**: Update `@nap-sft/tablsx` to `0.1.3`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Latest commit: `bd52f65`
   - Add optional `references.schema` to `ConstraintDefinition` for explicit cross-schema FK targets
   - Bare `references.table` falls back to `references.schema` (or the owning schema if absent)
   - Dotted `references.table` (e.g. `'admin.countries'`) still takes precedence when both forms are supplied
+  - Constraint-name hash now incorporates `references.schema` when present, preventing collisions for FKs differing only by target schema (existing constraint names unchanged for bare/dotted forms)
+  - Multi-dot `references.table` values (e.g. `'a.b.c'`) now throw `SchemaDefinitionError` instead of silently truncating
+  - `createTableSQL` accepts `schemaName` as an alias for `dbSchema`, matching `createIndexesSQL`
 
 ### 🛠 Chores
 

--- a/docs/reference/schema-types.md
+++ b/docs/reference/schema-types.md
@@ -98,7 +98,7 @@ A single constraint definition.
 interface ConstraintDefinition {
   type: 'PrimaryKey' | 'ForeignKey' | 'Unique' | 'Check' | 'Index';
   columns: string[];
-  references?: { table: string; columns: string[] };
+  references?: { table: string; columns: string[]; schema?: string };
   onDelete?: string;
   expression?: string;
 }

--- a/docs/reference/schema-types.md
+++ b/docs/reference/schema-types.md
@@ -99,6 +99,9 @@ interface ConstraintDefinition {
   type: 'PrimaryKey' | 'ForeignKey' | 'Unique' | 'Check' | 'Index';
   columns: string[];
   references?: { table: string; columns: string[]; schema?: string };
+  // For foreign keys. `schema` qualifies the target schema; alternatively,
+  // `table` may be dotted (e.g. 'admin.countries'), which takes precedence
+  // over `schema` when both are supplied.
   onDelete?: string;
   expression?: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -846,9 +846,9 @@
       }
     },
     "node_modules/@nap-sft/tablsx": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@nap-sft/tablsx/-/tablsx-0.1.2.tgz",
-      "integrity": "sha512-Irlbxp1IZVUQw8P2qXVCfYCH27PE8RQvI14utExkadqotUMel5/vfKPT0uYn/Kflz/rEXSUEkAC3JDadkakTPQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@nap-sft/tablsx/-/tablsx-0.1.3.tgz",
+      "integrity": "sha512-gsAbRGl7dPwU/Tt/+YgmwCM67sImUQ5p8mXJDQ9EiPreehayj8MYQ8ZT5N/ojseT32DjPKqTjgbcXwJWTJYFEg==",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pg-schemata",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pg-schemata",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@nap-sft/tablsx": "^0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
-        "@nap-sft/tablsx": "^0.1.2",
+        "@nap-sft/tablsx": "^0.1.3",
         "dotenv": "^16.5.0",
         "lodash": "^4.17.21",
         "lru-cache": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-schemata",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "homepage": "https://silverstone-i.github.io/pg-schemata/",
   "description": "A lightweight Postgres-first ORM layer built on top of pg-promise",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "git+https://github.com/silverstone-i/pg-schemata.git"
   },
   "dependencies": {
-    "@nap-sft/tablsx": "^0.1.2",
+    "@nap-sft/tablsx": "^0.1.3",
     "dotenv": "^16.5.0",
     "lodash": "^4.17.21",
     "lru-cache": "^11.1.0",

--- a/prd/rules/release-versioning-process.md
+++ b/prd/rules/release-versioning-process.md
@@ -178,7 +178,7 @@ npm view pg-schemata dist-tags
 
 1. Sync dev with main: `git switch dev && git merge --ff-only main && git push origin dev`
    - If dev has diverged: `git switch dev && git merge main && git push origin dev`
-2. Update documentation if applicable: `npm run docs`
+2. Update documentation if applicable: `npm run docs:build`
 3. Monitor for issues
 
 ---

--- a/src/schemaTypes.d.ts
+++ b/src/schemaTypes.d.ts
@@ -43,7 +43,7 @@ export interface ColumnDefinition {
  *
  * @property {'PrimaryKey'|'ForeignKey'|'Unique'|'Check'|'Index'} type - Type of constraint.
  * @property {Array<string>} columns - List of column names the constraint applies to.
- * @property {{ table: string, columns: Array<string> }} [references] - For foreign keys.
+ * @property {{ table: string, columns: Array<string>, schema?: string }} [references] - For foreign keys. `schema` qualifies the target schema; alternatively, `table` may be dotted (e.g. `'admin.foo'`), which takes precedence.
  * @property {string} [onDelete] - Optional ON DELETE behavior (e.g., 'CASCADE').
  * @property {string} [expression] - SQL expression for check constraints.
  */
@@ -53,6 +53,7 @@ export interface ConstraintDefinition {
   references?: {
     table: string;
     columns: string[];
+    schema?: string;
   };
   onDelete?: string;
   expression?: string;

--- a/src/utils/schemaBuilder.js
+++ b/src/utils/schemaBuilder.js
@@ -70,7 +70,7 @@ function resolveIndexes(schema) {
 function createTableSQL(schema, logger = null) {
   // Extract schema components: schema name, table name, columns, and constraints
   const { dbSchema, table, columns, constraints = {} } = schema;
-  const schemaName = dbSchema || 'public';
+  const schemaName = dbSchema || schema.schemaName || 'public';
 
   // Build column definitions with types, NOT NULL, and DEFAULT clauses
   const columnDefs = columns.map(col => {
@@ -146,17 +146,24 @@ function createTableSQL(schema, logger = null) {
         throw new SchemaDefinitionError(`Invalid foreign key reference for table ${table}: expected object, got ${typeof fk.references}`);
       }
 
-      const hash = createHash(table + fk.references.table + fk.columns.join('_'));
-      const constraintName = `fk_${table}_${hash}`;
-
       let refSchema;
       let refTable;
       if (fk.references.table.includes('.')) {
-        [refSchema, refTable] = fk.references.table.split('.');
+        const dotIdx = fk.references.table.indexOf('.');
+        const left = fk.references.table.slice(0, dotIdx);
+        const right = fk.references.table.slice(dotIdx + 1);
+        if (!left || !right || right.includes('.')) {
+          throw new SchemaDefinitionError(`Invalid foreign key reference for table ${table}: expected '<schema>.<table>', got '${fk.references.table}'`);
+        }
+        refSchema = left;
+        refTable = right;
       } else {
         refSchema = fk.references.schema ?? schemaName;
         refTable = fk.references.table;
       }
+
+      const hash = createHash(table + fk.references.table + (fk.references.schema ?? '') + fk.columns.join('_'));
+      const constraintName = `fk_${table}_${hash}`;
 
       tableConstraints.push(`CONSTRAINT "${constraintName}" FOREIGN KEY (${fk.columns.map(c => `"${c}"`).join(', ')}) ` + `REFERENCES "${refSchema}"."${refTable}" (${fk.references.columns.map(c => `"${c}"`).join(', ')})` + (fk.onDelete ? ` ON DELETE ${fk.onDelete}` : '') + (fk.onUpdate ? ` ON UPDATE ${fk.onUpdate}` : ''));
     }

--- a/src/utils/schemaBuilder.js
+++ b/src/utils/schemaBuilder.js
@@ -146,9 +146,10 @@ function createTableSQL(schema, logger = null) {
         throw new SchemaDefinitionError(`Invalid foreign key reference for table ${table}: expected object, got ${typeof fk.references}`);
       }
 
+      const isDotted = fk.references.table.includes('.');
       let refSchema;
       let refTable;
-      if (fk.references.table.includes('.')) {
+      if (isDotted) {
         const dotIdx = fk.references.table.indexOf('.');
         const left = fk.references.table.slice(0, dotIdx);
         const right = fk.references.table.slice(dotIdx + 1);
@@ -162,7 +163,11 @@ function createTableSQL(schema, logger = null) {
         refTable = fk.references.table;
       }
 
-      const hash = createHash(table + fk.references.table + (fk.references.schema ?? '') + fk.columns.join('_'));
+      // Hash only mixes in references.schema when it actually drives resolution
+      // (i.e. the table is not dotted). Dotted form ignores references.schema, so
+      // it must not affect the constraint name either.
+      const hashSchemaPart = !isDotted && fk.references.schema ? fk.references.schema : '';
+      const hash = createHash(table + fk.references.table + hashSchemaPart + fk.columns.join('_'));
       const constraintName = `fk_${table}_${hash}`;
 
       tableConstraints.push(`CONSTRAINT "${constraintName}" FOREIGN KEY (${fk.columns.map(c => `"${c}"`).join(', ')}) ` + `REFERENCES "${refSchema}"."${refTable}" (${fk.references.columns.map(c => `"${c}"`).join(', ')})` + (fk.onDelete ? ` ON DELETE ${fk.onDelete}` : '') + (fk.onUpdate ? ` ON UPDATE ${fk.onUpdate}` : ''));

--- a/src/utils/schemaBuilder.js
+++ b/src/utils/schemaBuilder.js
@@ -149,7 +149,14 @@ function createTableSQL(schema, logger = null) {
       const hash = createHash(table + fk.references.table + fk.columns.join('_'));
       const constraintName = `fk_${table}_${hash}`;
 
-      const [refSchema, refTable] = fk.references.table.includes('.') ? fk.references.table.split('.') : [schemaName, fk.references.table];
+      let refSchema;
+      let refTable;
+      if (fk.references.table.includes('.')) {
+        [refSchema, refTable] = fk.references.table.split('.');
+      } else {
+        refSchema = fk.references.schema ?? schemaName;
+        refTable = fk.references.table;
+      }
 
       tableConstraints.push(`CONSTRAINT "${constraintName}" FOREIGN KEY (${fk.columns.map(c => `"${c}"`).join(', ')}) ` + `REFERENCES "${refSchema}"."${refTable}" (${fk.references.columns.map(c => `"${c}"`).join(', ')})` + (fk.onDelete ? ` ON DELETE ${fk.onDelete}` : '') + (fk.onUpdate ? ` ON UPDATE ${fk.onUpdate}` : ''));
     }

--- a/tests/unit/schemaBuilder.test.js
+++ b/tests/unit/schemaBuilder.test.js
@@ -176,6 +176,24 @@ describe('Schema Utilities', () => {
       expect(normalizeSQL(sql)).toMatch(/REFERENCES "admin"\."countries"/);
     });
 
+    it('should produce identical constraint names for dotted FKs regardless of references.schema', () => {
+      const baseSchema = (refs) => ({
+        schemaName: 'tenant_a',
+        table: 'orders',
+        columns: [
+          { name: 'id', type: 'serial', notNull: true },
+          { name: 'country_id', type: 'int', notNull: true },
+        ],
+        constraints: { foreignKeys: [{ columns: ['country_id'], references: refs }] },
+      });
+
+      const sqlWithoutSchema = createTableSQL(baseSchema({ table: 'admin.countries', columns: ['id'] }));
+      const sqlWithIgnoredSchema = createTableSQL(baseSchema({ schema: 'ignored', table: 'admin.countries', columns: ['id'] }));
+
+      const nameOf = sql => sql.match(/CONSTRAINT "(fk_orders_[a-z0-9]{6})"/)[1];
+      expect(nameOf(sqlWithoutSchema)).toBe(nameOf(sqlWithIgnoredSchema));
+    });
+
     it('should throw on a multi-dot references.table value', () => {
       const schema = {
         schemaName: 'tenant_a',

--- a/tests/unit/schemaBuilder.test.js
+++ b/tests/unit/schemaBuilder.test.js
@@ -88,6 +88,94 @@ describe('Schema Utilities', () => {
       expect(normalizeSQL(sql)).toMatch(/CONSTRAINT "fk_posts_[a-z0-9]{6}" FOREIGN KEY \("user_id", "tenant_id"\) REFERENCES "public"\."users" \("id", "tenant_id"\)/);
     });
 
+    it('should resolve cross-schema FK target via dotted references.table', () => {
+      const schema = {
+        schemaName: 'tenant_a',
+        table: 'orders',
+        columns: [
+          { name: 'id', type: 'serial', notNull: true },
+          { name: 'country_id', type: 'int', notNull: true },
+        ],
+        constraints: {
+          foreignKeys: [
+            {
+              columns: ['country_id'],
+              references: { table: 'admin.countries', columns: ['id'] },
+            },
+          ],
+        },
+      };
+
+      const sql = createTableSQL(schema);
+      expect(normalizeSQL(sql)).toMatch(/REFERENCES "admin"\."countries"/);
+    });
+
+    it('should resolve cross-schema FK target via explicit references.schema', () => {
+      const schema = {
+        schemaName: 'tenant_a',
+        table: 'orders',
+        columns: [
+          { name: 'id', type: 'serial', notNull: true },
+          { name: 'country_id', type: 'int', notNull: true },
+        ],
+        constraints: {
+          foreignKeys: [
+            {
+              columns: ['country_id'],
+              references: { schema: 'admin', table: 'countries', columns: ['id'] },
+            },
+          ],
+        },
+      };
+
+      const sql = createTableSQL(schema);
+      expect(normalizeSQL(sql)).toMatch(/REFERENCES "admin"\."countries"/);
+    });
+
+    it('should fall back to own schemaName for bare same-schema FK references', () => {
+      const schema = {
+        schemaName: 'public',
+        table: 'orders',
+        columns: [
+          { name: 'id', type: 'serial', notNull: true },
+          { name: 'user_id', type: 'int', notNull: true },
+        ],
+        constraints: {
+          foreignKeys: [
+            {
+              columns: ['user_id'],
+              references: { table: 'users', columns: ['id'] },
+            },
+          ],
+        },
+      };
+
+      const sql = createTableSQL(schema);
+      expect(normalizeSQL(sql)).toMatch(/REFERENCES "public"\."users"/);
+    });
+
+    it('should let dotted references.table win when both dotted form and schema are supplied', () => {
+      const schema = {
+        schemaName: 'tenant_a',
+        table: 'orders',
+        columns: [
+          { name: 'id', type: 'serial', notNull: true },
+          { name: 'country_id', type: 'int', notNull: true },
+        ],
+        constraints: {
+          foreignKeys: [
+            {
+              columns: ['country_id'],
+              references: { schema: 'ignored', table: 'admin.countries', columns: ['id'] },
+            },
+          ],
+        },
+      };
+
+      const sql = createTableSQL(schema);
+      expect(normalizeSQL(sql)).toMatch(/REFERENCES "admin"\."countries"/);
+    });
+
     it('should throw an error for invalid foreign key reference', () => {
       const schema = {
         schemaName: 'public',

--- a/tests/unit/schemaBuilder.test.js
+++ b/tests/unit/schemaBuilder.test.js
@@ -176,6 +176,69 @@ describe('Schema Utilities', () => {
       expect(normalizeSQL(sql)).toMatch(/REFERENCES "admin"\."countries"/);
     });
 
+    it('should throw on a multi-dot references.table value', () => {
+      const schema = {
+        schemaName: 'tenant_a',
+        table: 'orders',
+        columns: [
+          { name: 'id', type: 'serial', notNull: true },
+          { name: 'country_id', type: 'int', notNull: true },
+        ],
+        constraints: {
+          foreignKeys: [
+            {
+              columns: ['country_id'],
+              references: { table: 'a.b.c', columns: ['id'] },
+            },
+          ],
+        },
+      };
+
+      expect(() => createTableSQL(schema)).toThrow(/expected '<schema>\.<table>'/);
+    });
+
+    it('should produce distinct constraint names for FKs differing only by references.schema', () => {
+      const schema = {
+        schemaName: 'tenant_a',
+        table: 'orders',
+        columns: [
+          { name: 'id', type: 'serial', notNull: true },
+          { name: 'a_country_id', type: 'int', notNull: true },
+          { name: 'b_country_id', type: 'int', notNull: true },
+        ],
+        constraints: {
+          foreignKeys: [
+            { columns: ['a_country_id'], references: { schema: 'admin', table: 'countries', columns: ['id'] } },
+            { columns: ['b_country_id'], references: { schema: 'archive', table: 'countries', columns: ['id'] } },
+          ],
+        },
+      };
+
+      const sql = createTableSQL(schema);
+      const names = [...sql.matchAll(/CONSTRAINT "(fk_orders_[a-z0-9]{6})"/g)].map(m => m[1]);
+      expect(names).toHaveLength(2);
+      expect(names[0]).not.toBe(names[1]);
+    });
+
+    it('should resolve bare references.table against non-public owning schemaName', () => {
+      const schema = {
+        schemaName: 'tenant_a',
+        table: 'orders',
+        columns: [
+          { name: 'id', type: 'serial', notNull: true },
+          { name: 'user_id', type: 'int', notNull: true },
+        ],
+        constraints: {
+          foreignKeys: [
+            { columns: ['user_id'], references: { table: 'users', columns: ['id'] } },
+          ],
+        },
+      };
+
+      const sql = createTableSQL(schema);
+      expect(normalizeSQL(sql)).toMatch(/REFERENCES "tenant_a"\."users"/);
+    });
+
     it('should throw an error for invalid foreign key reference', () => {
       const schema = {
         schemaName: 'public',


### PR DESCRIPTION
## Summary

- **fix(schemaBuilder)**: honor target schema on foreign key constraints — adds optional `references.schema` field; dotted `references.table` still wins when both supplied.
- **chore(deps)**: bump `@nap-sft/tablsx` to `0.1.3`.
- **docs**: document `references.schema` in `ConstraintDefinition`; correct release-process script name to `docs:build`; add v1.3.2 CHANGELOG entry.

## Test plan

- [x] `npm run test:unit` — 187/187 passing (includes 4 new cross-schema FK tests)
- [x] `npx eslint` clean on changed source/tests
- [x] CI green on this PR
- [x] After merge: tag `v1.3.2` on main, push tag → `publish-release.yml` publishes to npm `--tag latest`
- [x] Post-release: sync `dev` with `main` via `--ff-only`