### PR TITLE
fix: auto-fill updated_by on insert and bulkInsert

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,8 @@ export default [
       "node_modules/**",
       "pg-schemata-docs/**",
       "Examples/**",
+      "docs/.vitepress/dist/**",
+      "docs/.vitepress/cache/**",
     ],
   },
   {

--- a/src/TableModel.js
+++ b/src/TableModel.js
@@ -161,7 +161,7 @@ class TableModel extends QueryModel {
     const softCheck = this._schema.softDelete ? ' AND deactivated_at IS NULL' : '';
     const query = `DELETE FROM ${this.schemaName}.${this.tableName} WHERE id = $1${softCheck}`;
     try {
-      return await this.db.result(query, [id], r => r.rowCount);
+      return await this.db.result(query, [id], (r) => r.rowCount);
     } catch (err) {
       this.handleDbError(err);
     }
@@ -212,7 +212,7 @@ class TableModel extends QueryModel {
       condition +
       ' RETURNING *';
     try {
-      const result = await this.db.result(query, undefined, r => ({
+      const result = await this.db.result(query, undefined, (r) => ({
         rowCount: r.rowCount,
         row: r.rows?.[0] ?? null,
       }));
@@ -252,12 +252,13 @@ class TableModel extends QueryModel {
     });
 
     const auditExclude = this._auditEnabled() ? ['created_at', 'created_by', 'updated_at', 'updated_by'] : [];
-    const columnsToUpdate = (updateColumns || Object.keys(safeDto).filter(col => !conflictColumns.includes(col) && col !== 'id'))
-      .filter(col => !auditExclude.includes(col));
+    const columnsToUpdate = (updateColumns || Object.keys(safeDto).filter((col) => !conflictColumns.includes(col) && col !== 'id')).filter(
+      (col) => !auditExclude.includes(col),
+    );
 
     const auditUpdate = this._auditEnabled() ? 'updated_at = NOW(), updated_by = EXCLUDED.updated_by' : '';
     const setParts = [
-      ...(columnsToUpdate.length ? [columnsToUpdate.map(col => `${col} = EXCLUDED.${col}`).join(', ')] : []),
+      ...(columnsToUpdate.length ? [columnsToUpdate.map((col) => `${col} = EXCLUDED.${col}`).join(', ')] : []),
       ...(auditUpdate ? [auditUpdate] : []),
     ];
 
@@ -298,7 +299,7 @@ class TableModel extends QueryModel {
       throw new SchemaDefinitionError('Expected returning to be an array of column names');
     }
 
-    const safeRecords = records.map(dto => {
+    const safeRecords = records.map((dto) => {
       const sanitized = this.sanitizeDto(dto);
       if (this._auditEnabled()) {
         if (!Object.prototype.hasOwnProperty.call(sanitized, 'created_by')) {
@@ -316,12 +317,13 @@ class TableModel extends QueryModel {
     });
 
     const auditExclude = this._auditEnabled() ? ['created_at', 'created_by', 'updated_at', 'updated_by'] : [];
-    const columnsToUpdate = (updateColumns || Object.keys(safeRecords[0]).filter(col => !conflictColumns.includes(col) && col !== 'id'))
-      .filter(col => !auditExclude.includes(col));
+    const columnsToUpdate = (
+      updateColumns || Object.keys(safeRecords[0]).filter((col) => !conflictColumns.includes(col) && col !== 'id')
+    ).filter((col) => !auditExclude.includes(col));
 
     const auditUpdate = this._auditEnabled() ? 'updated_at = NOW(), updated_by = EXCLUDED.updated_by' : '';
     const setParts = [
-      ...(columnsToUpdate.length ? [columnsToUpdate.map(col => `${col} = EXCLUDED.${col}`).join(', ')] : []),
+      ...(columnsToUpdate.length ? [columnsToUpdate.map((col) => `${col} = EXCLUDED.${col}`).join(', ')] : []),
       ...(auditUpdate ? [auditUpdate] : []),
     ];
 
@@ -339,11 +341,11 @@ class TableModel extends QueryModel {
     `;
 
     try {
-      return await this.db.tx(async t => {
+      return await this.db.tx(async (t) => {
         if (returning) {
           return await t.any(query);
         }
-        return await t.result(query, [], r => r.rowCount);
+        return await t.result(query, [], (r) => r.rowCount);
       });
     } catch (err) {
       this.handleDbError(err);
@@ -368,7 +370,7 @@ class TableModel extends QueryModel {
     }
     const query = `DELETE FROM ${this.schemaName}.${this.tableName} WHERE ${clause}`;
     try {
-      return await this.db.result(query, values, r => r.rowCount);
+      return await this.db.result(query, values, (r) => r.rowCount);
     } catch (err) {
       this.handleDbError(err);
     }
@@ -397,7 +399,7 @@ class TableModel extends QueryModel {
   async updateWhere(where, updates, options = {}) {
     const { includeDeactivated = false } = options;
 
-    const isNonEmpty = val => (Array.isArray(val) ? val.length > 0 : isPlainObject(val) ? Object.keys(val).length > 0 : false);
+    const isNonEmpty = (val) => (Array.isArray(val) ? val.length > 0 : isPlainObject(val) ? Object.keys(val).length > 0 : false);
 
     if (!isNonEmpty(where)) {
       throw new SchemaDefinitionError('WHERE clause must be a non-empty object or non-empty array');
@@ -439,7 +441,7 @@ class TableModel extends QueryModel {
 
     const query = `${setClause} WHERE ${clause}`;
     try {
-      const result = await this.db.result(query, values, r => r.rowCount);
+      const result = await this.db.result(query, values, (r) => r.rowCount);
       return result;
     } catch (err) {
       this.handleDbError(err);
@@ -471,7 +473,7 @@ class TableModel extends QueryModel {
       this.validateDto(records, this._schema.validators.insertValidator, 'Insert DTO');
     }
 
-    const safeRecords = records.map(dto => {
+    const safeRecords = records.map((dto) => {
       const sanitized = this.sanitizeDto(dto);
       if (this._auditEnabled()) {
         if (!Object.prototype.hasOwnProperty.call(sanitized, 'created_by')) {
@@ -498,20 +500,21 @@ class TableModel extends QueryModel {
       table: { table: this._schema.table, schema: this._schema.dbSchema },
     });
 
-    const query = this.pgp.helpers.insert(safeRecords, cs) + (Array.isArray(returning) && returning.length > 0 ? ` RETURNING ${returning.join(', ')}` : '');
+    const query =
+      this.pgp.helpers.insert(safeRecords, cs) + (Array.isArray(returning) && returning.length > 0 ? ` RETURNING ${returning.join(', ')}` : '');
 
     try {
       if (tx) {
         if (returning) {
           return await tx.any(query);
         }
-        return await tx.result(query, [], r => r.rowCount);
+        return await tx.result(query, [], (r) => r.rowCount);
       } else {
-        return await this.db.tx(async t => {
+        return await this.db.tx(async (t) => {
           if (returning) {
             return await t.any(query);
           }
-          return await t.result(query, [], r => r.rowCount);
+          return await t.result(query, [], (r) => r.rowCount);
         });
       }
     } catch (err) {
@@ -544,15 +547,15 @@ class TableModel extends QueryModel {
       this.validateDto(records, this._schema.validators.updateValidator, 'Update DTO');
     }
 
-    const queries = records.map(dto => {
+    const queries = records.map((dto) => {
       const id = dto.id;
       if (!isValidId(id)) {
         throw new SchemaDefinitionError(`Invalid ID in record: ${JSON.stringify(dto)}`);
       }
       const safeDto = this.sanitizeDto(dto, { includeImmutable: false });
       if (this._auditEnabled() && !Object.prototype.hasOwnProperty.call(safeDto, 'updated_by')) {
-      safeDto.updated_by = this._resolveAuditActor();
-    }
+        safeDto.updated_by = this._resolveAuditActor();
+      }
       delete safeDto.id;
       const softCheck = this._schema.softDelete ? ' AND deactivated_at IS NULL' : '';
       const condition = this.pgp.as.format('WHERE id = $1', [id]) + softCheck;
@@ -568,9 +571,11 @@ class TableModel extends QueryModel {
 
     try {
       if (tx) {
-        return await tx.batch(queries.map(q => (returning ? tx.any(q.query, [q.id]) : tx.result(q.query, [q.id], r => r.rowCount))));
+        return await tx.batch(queries.map((q) => (returning ? tx.any(q.query, [q.id]) : tx.result(q.query, [q.id], (r) => r.rowCount))));
       } else {
-        return await this.db.tx(async t => t.batch(queries.map(q => (returning ? t.any(q.query, [q.id]) : t.result(q.query, [q.id], r => r.rowCount)))));
+        return await this.db.tx(async (t) =>
+          t.batch(queries.map((q) => (returning ? t.any(q.query, [q.id]) : t.result(q.query, [q.id], (r) => r.rowCount)))),
+        );
       }
     } catch (err) {
       this.handleDbError(err);
@@ -607,7 +612,7 @@ class TableModel extends QueryModel {
       const cellRow = sheet.getRow(i);
 
       if (i === 0) {
-        headers = cellRow.map(cell => cell.value);
+        headers = cellRow.map((cell) => cell.value);
         continue;
       }
 
@@ -674,7 +679,7 @@ class TableModel extends QueryModel {
     }
 
     const query = `UPDATE ${this.schemaName}.${this.tableName} SET ${setClause} WHERE ${clause}`;
-    return this.db.result(query, values, r => r.rowCount);
+    return this.db.result(query, values, (r) => r.rowCount);
   }
 
   /**
@@ -698,7 +703,7 @@ class TableModel extends QueryModel {
     }
 
     const query = `UPDATE ${this.schemaName}.${this.tableName} SET ${setClause} WHERE ${clause}`;
-    return this.db.result(query, values, r => r.rowCount);
+    return this.db.result(query, values, (r) => r.rowCount);
   }
 
   /**

--- a/src/TableModel.js
+++ b/src/TableModel.js
@@ -74,6 +74,22 @@ class TableModel extends QueryModel {
   }
 
   /**
+   * True when this table's schema enables audit fields. `hasAuditFields` may
+   * be either a boolean or an object `{ enabled, userFields?, ... }`; this
+   * helper normalizes both shapes so CRUD paths agree with addAuditFields()
+   * and createColumnSet() (which both gate on === true / .enabled === true).
+   *
+   * @returns {boolean}
+   * @private
+   */
+  _auditEnabled() {
+    const cfg = this._schema.hasAuditFields;
+    if (cfg === true) return true;
+    if (cfg && typeof cfg === 'object') return cfg.enabled === true;
+    return false;
+  }
+
+  /**
    * Inserts a single row into the table after validation and sanitization.
    * @param {Object} dto - Data to insert.
    * @returns {Promise<Object>} The inserted row.
@@ -106,7 +122,7 @@ class TableModel extends QueryModel {
     if (Object.keys(safeDto).length === 0) {
       return Promise.reject(new SchemaDefinitionError('DTO must contain at least one valid column'));
     }
-    if (this._schema.hasAuditFields) {
+    if (this._auditEnabled()) {
       if (!Object.prototype.hasOwnProperty.call(safeDto, 'created_by')) {
         safeDto.created_by = this._resolveAuditActor();
       }
@@ -182,7 +198,7 @@ class TableModel extends QueryModel {
       return Promise.reject(error);
     }
     const safeDto = this.sanitizeDto(dto, { includeImmutable: false });
-    if (this._schema.hasAuditFields && !Object.prototype.hasOwnProperty.call(safeDto, 'updated_by')) {
+    if (this._auditEnabled() && !Object.prototype.hasOwnProperty.call(safeDto, 'updated_by')) {
       safeDto.updated_by = this._resolveAuditActor();
     }
     const softCheck = this._schema.softDelete ? ' AND deactivated_at IS NULL' : '';
@@ -222,7 +238,7 @@ class TableModel extends QueryModel {
     }
 
     const safeDto = this.sanitizeDto(dto);
-    if (this._schema.hasAuditFields) {
+    if (this._auditEnabled()) {
       if (!Object.prototype.hasOwnProperty.call(safeDto, 'created_by')) {
         safeDto.created_by = this._resolveAuditActor();
       }
@@ -235,11 +251,11 @@ class TableModel extends QueryModel {
       table: { table: this._schema.table, schema: this._schema.dbSchema },
     });
 
-    const auditExclude = this._schema.hasAuditFields ? ['created_at', 'created_by', 'updated_at', 'updated_by'] : [];
+    const auditExclude = this._auditEnabled() ? ['created_at', 'created_by', 'updated_at', 'updated_by'] : [];
     const columnsToUpdate = (updateColumns || Object.keys(safeDto).filter(col => !conflictColumns.includes(col) && col !== 'id'))
       .filter(col => !auditExclude.includes(col));
 
-    const auditUpdate = this._schema.hasAuditFields ? 'updated_at = NOW(), updated_by = EXCLUDED.updated_by' : '';
+    const auditUpdate = this._auditEnabled() ? 'updated_at = NOW(), updated_by = EXCLUDED.updated_by' : '';
     const setParts = [
       ...(columnsToUpdate.length ? [columnsToUpdate.map(col => `${col} = EXCLUDED.${col}`).join(', ')] : []),
       ...(auditUpdate ? [auditUpdate] : []),
@@ -284,7 +300,7 @@ class TableModel extends QueryModel {
 
     const safeRecords = records.map(dto => {
       const sanitized = this.sanitizeDto(dto);
-      if (this._schema.hasAuditFields) {
+      if (this._auditEnabled()) {
         if (!Object.prototype.hasOwnProperty.call(sanitized, 'created_by')) {
           sanitized.created_by = this._resolveAuditActor();
         }
@@ -299,11 +315,11 @@ class TableModel extends QueryModel {
       table: { table: this._schema.table, schema: this._schema.dbSchema },
     });
 
-    const auditExclude = this._schema.hasAuditFields ? ['created_at', 'created_by', 'updated_at', 'updated_by'] : [];
+    const auditExclude = this._auditEnabled() ? ['created_at', 'created_by', 'updated_at', 'updated_by'] : [];
     const columnsToUpdate = (updateColumns || Object.keys(safeRecords[0]).filter(col => !conflictColumns.includes(col) && col !== 'id'))
       .filter(col => !auditExclude.includes(col));
 
-    const auditUpdate = this._schema.hasAuditFields ? 'updated_at = NOW(), updated_by = EXCLUDED.updated_by' : '';
+    const auditUpdate = this._auditEnabled() ? 'updated_at = NOW(), updated_by = EXCLUDED.updated_by' : '';
     const setParts = [
       ...(columnsToUpdate.length ? [columnsToUpdate.map(col => `${col} = EXCLUDED.${col}`).join(', ')] : []),
       ...(auditUpdate ? [auditUpdate] : []),
@@ -410,7 +426,7 @@ class TableModel extends QueryModel {
 
     const safeUpdates = this.sanitizeDto(updates, { includeImmutable: false });
 
-    if (this._schema.hasAuditFields && !Object.prototype.hasOwnProperty.call(safeUpdates, 'updated_by')) {
+    if (this._auditEnabled() && !Object.prototype.hasOwnProperty.call(safeUpdates, 'updated_by')) {
       safeUpdates.updated_by = this._resolveAuditActor();
     }
     const updateCs = new this.pgp.helpers.ColumnSet(Object.keys(safeUpdates), {
@@ -457,7 +473,7 @@ class TableModel extends QueryModel {
 
     const safeRecords = records.map(dto => {
       const sanitized = this.sanitizeDto(dto);
-      if (this._schema.hasAuditFields) {
+      if (this._auditEnabled()) {
         if (!Object.prototype.hasOwnProperty.call(sanitized, 'created_by')) {
           sanitized.created_by = this._resolveAuditActor();
         }
@@ -534,7 +550,7 @@ class TableModel extends QueryModel {
         throw new SchemaDefinitionError(`Invalid ID in record: ${JSON.stringify(dto)}`);
       }
       const safeDto = this.sanitizeDto(dto, { includeImmutable: false });
-      if (this._schema.hasAuditFields && !Object.prototype.hasOwnProperty.call(safeDto, 'updated_by')) {
+      if (this._auditEnabled() && !Object.prototype.hasOwnProperty.call(safeDto, 'updated_by')) {
       safeDto.updated_by = this._resolveAuditActor();
     }
       delete safeDto.id;
@@ -649,7 +665,7 @@ class TableModel extends QueryModel {
     clause = `${prefix}${softCheck}`;
 
     let setClause = 'deactivated_at = NOW()';
-    if (this._schema.hasAuditFields) {
+    if (this._auditEnabled()) {
       const actor = this._resolveAuditActor();
       if (actor != null) {
         values.push(actor);
@@ -673,7 +689,7 @@ class TableModel extends QueryModel {
     const { clause, values } = this.buildWhereClause(where, true, [], 'AND', true);
 
     let setClause = 'deactivated_at = NULL';
-    if (this._schema.hasAuditFields) {
+    if (this._auditEnabled()) {
       const actor = this._resolveAuditActor();
       if (actor != null) {
         values.push(actor);

--- a/src/TableModel.js
+++ b/src/TableModel.js
@@ -106,8 +106,16 @@ class TableModel extends QueryModel {
     if (Object.keys(safeDto).length === 0) {
       return Promise.reject(new SchemaDefinitionError('DTO must contain at least one valid column'));
     }
-    if (this._schema.hasAuditFields && !Object.prototype.hasOwnProperty.call(safeDto, 'created_by')) {
-      safeDto.created_by = this._resolveAuditActor();
+    if (this._schema.hasAuditFields) {
+      if (!Object.prototype.hasOwnProperty.call(safeDto, 'created_by')) {
+        safeDto.created_by = this._resolveAuditActor();
+      }
+      // Mirror created_by → updated_by on initial insert so both audit
+      // columns are populated consistently. Matches the pattern upsert()
+      // already follows. Callers can still override updated_by explicitly.
+      if (!Object.prototype.hasOwnProperty.call(safeDto, 'updated_by')) {
+        safeDto.updated_by = safeDto.created_by;
+      }
     }
     let query;
     try {
@@ -449,8 +457,15 @@ class TableModel extends QueryModel {
 
     const safeRecords = records.map(dto => {
       const sanitized = this.sanitizeDto(dto);
-      if (this._schema.hasAuditFields && !Object.prototype.hasOwnProperty.call(sanitized, 'created_by')) {
-        sanitized.created_by = this._resolveAuditActor();
+      if (this._schema.hasAuditFields) {
+        if (!Object.prototype.hasOwnProperty.call(sanitized, 'created_by')) {
+          sanitized.created_by = this._resolveAuditActor();
+        }
+        // Mirror created_by → updated_by on insert so both audit columns are
+        // populated consistently (matches insert() and upsert()).
+        if (!Object.prototype.hasOwnProperty.call(sanitized, 'updated_by')) {
+          sanitized.updated_by = sanitized.created_by;
+        }
       }
       return sanitized;
     });

--- a/src/utils/schemaBuilder.js
+++ b/src/utils/schemaBuilder.js
@@ -542,10 +542,12 @@ function createColumnSet(schema, pgp, logger = null) {
   });
 
   // Create separate ColumnSet variants for insert and update to include audit fields.
-  // The insert variant carries both `created_by` and `updated_by` so the new mirror-on-
-  // insert behavior in TableModel.insert/bulkInsert actually persists `updated_by` —
-  // pg-promise omits any column not in the ColumnSet, so the DTO assignment alone
-  // wouldn't reach the SQL.
+  // The insert variant carries both `created_by` and `updated_by` so the mirror-on-
+  // insert behavior in TableModel.insert() (which uses this.cs.insert) actually
+  // persists `updated_by` — pg-promise omits any column not in the ColumnSet, so
+  // the DTO assignment alone wouldn't reach the SQL.
+  // bulkInsert() builds its own ColumnSet from the safeRecords keys and does not
+  // depend on this cs.insert.
   if (hasAuditFields) {
     cs.insert = cs[schema.table].extend(['created_by', 'updated_by']);
     cs.update = cs[schema.table].extend([

--- a/src/utils/schemaBuilder.js
+++ b/src/utils/schemaBuilder.js
@@ -541,9 +541,13 @@ function createColumnSet(schema, pgp, logger = null) {
     },
   });
 
-  // Create separate ColumnSet variants for insert and update to include audit fields
+  // Create separate ColumnSet variants for insert and update to include audit fields.
+  // The insert variant carries both `created_by` and `updated_by` so the new mirror-on-
+  // insert behavior in TableModel.insert/bulkInsert actually persists `updated_by` —
+  // pg-promise omits any column not in the ColumnSet, so the DTO assignment alone
+  // wouldn't reach the SQL.
   if (hasAuditFields) {
-    cs.insert = cs[schema.table].extend(['created_by']);
+    cs.insert = cs[schema.table].extend(['created_by', 'updated_by']);
     cs.update = cs[schema.table].extend([
       {
         name: 'updated_at',

--- a/tests/integration/TableModel.integration.test.js
+++ b/tests/integration/TableModel.integration.test.js
@@ -207,6 +207,54 @@ describe('TableModel Integration', () => {
     expect(found.email).toBe('test@example.com');
   });
 
+  test('insert mirrors created_by → updated_by when caller omits updated_by', async () => {
+    // Regression: prior to the mirror-on-insert fix, updated_by was dropped
+    // entirely from the INSERT (ColumnSet only extended created_by), so this
+    // assertion would land null even though the application code intended to
+    // populate both columns. Reproduces end-to-end against a real DB.
+    const row = await model.insert({
+      email: 'mirror@example.com',
+      created_by: 'mirror-actor',
+      tenant_id: TENANT_ID,
+    });
+    const found = await model.findById(row.id);
+    expect(found.created_by).toBe('mirror-actor');
+    expect(found.updated_by).toBe('mirror-actor');
+  });
+
+  test('insert preserves explicit updated_by when caller supplies it', async () => {
+    const row = await model.insert({
+      email: 'mirror-explicit@example.com',
+      created_by: 'mirror-creator',
+      updated_by: 'mirror-updater',
+      tenant_id: TENANT_ID,
+    });
+    const found = await model.findById(row.id);
+    expect(found.created_by).toBe('mirror-creator');
+    expect(found.updated_by).toBe('mirror-updater');
+  });
+
+  test('bulkInsert mirrors created_by → updated_by per record', async () => {
+    const inserted = await model.bulkInsert(
+      [
+        { email: 'bulk-mirror-a@example.com', created_by: 'bulk-actor', tenant_id: TENANT_ID },
+        { email: 'bulk-mirror-b@example.com', created_by: 'bulk-actor', updated_by: 'bulk-explicit', tenant_id: TENANT_ID },
+      ],
+      ['id', 'email'],
+    );
+    const ids = inserted.map((r) => r.id);
+    const rows = await ctx.db.any(
+      `SELECT email, created_by, updated_by FROM "${model.schema.dbSchema}"."${model.schema.table}" WHERE id IN ($1:csv) ORDER BY email`,
+      [ids],
+    );
+    expect(rows[0].email).toBe('bulk-mirror-a@example.com');
+    expect(rows[0].created_by).toBe('bulk-actor');
+    expect(rows[0].updated_by).toBe('bulk-actor');     // mirrored
+    expect(rows[1].email).toBe('bulk-mirror-b@example.com');
+    expect(rows[1].created_by).toBe('bulk-actor');
+    expect(rows[1].updated_by).toBe('bulk-explicit');  // explicit wins
+  });
+
   test('manual update for user email', async () => {
     const user = await model.insert({
       email: 'manual@test.com',

--- a/tests/unit/TableModel.test.js
+++ b/tests/unit/TableModel.test.js
@@ -98,6 +98,40 @@ describe('TableModel (Unit)', () => {
         });
         await expect(model.insert({ invalid: 'value' })).rejects.toThrow('DTO must contain at least one valid column');
       });
+
+      test('mirrors created_by → updated_by when hasAuditFields and updated_by not supplied', async () => {
+        const auditSchema = {
+          ...mockSchema,
+          hasAuditFields: true,
+          columns: [...mockSchema.columns, { name: 'created_by' }, { name: 'updated_by' }],
+        };
+        const auditModel = new TableModel(mockDb, mockPgp, auditSchema);
+        auditModel._resolveAuditActor = vi.fn(() => 'actor-uuid');
+        mockDb.one.mockResolvedValue({ id: 1 });
+
+        await auditModel.insert({ email: 'test@example.com' });
+
+        const dtoPassedToInsert = mockPgp.helpers.insert.mock.calls.at(-1)[0];
+        expect(dtoPassedToInsert.created_by).toBe('actor-uuid');
+        expect(dtoPassedToInsert.updated_by).toBe('actor-uuid');
+      });
+
+      test('preserves explicit updated_by when caller supplies it on insert', async () => {
+        const auditSchema = {
+          ...mockSchema,
+          hasAuditFields: true,
+          columns: [...mockSchema.columns, { name: 'created_by' }, { name: 'updated_by' }],
+        };
+        const auditModel = new TableModel(mockDb, mockPgp, auditSchema);
+        auditModel._resolveAuditActor = vi.fn(() => 'actor-uuid');
+        mockDb.one.mockResolvedValue({ id: 1 });
+
+        await auditModel.insert({ email: 'test@example.com', updated_by: 'explicit-actor' });
+
+        const dtoPassedToInsert = mockPgp.helpers.insert.mock.calls.at(-1)[0];
+        expect(dtoPassedToInsert.created_by).toBe('actor-uuid');
+        expect(dtoPassedToInsert.updated_by).toBe('explicit-actor');
+      });
     });
 
     describe('Update', () => {
@@ -165,6 +199,34 @@ describe('TableModel (Unit)', () => {
 
       test('should throw if records is not an array', async () => {
         await expect(model.bulkInsert('invalid')).rejects.toThrow('Records must be a non-empty array');
+      });
+
+      test('mirrors created_by → updated_by on every record when hasAuditFields', async () => {
+        const auditSchema = {
+          ...mockSchema,
+          hasAuditFields: true,
+          columns: [...mockSchema.columns, { name: 'created_by' }, { name: 'updated_by' }],
+        };
+        const auditModel = new TableModel(mockDb, mockPgp, auditSchema);
+        auditModel._resolveAuditActor = vi.fn(() => 'actor-uuid');
+        mockDb.tx = vi.fn(fn =>
+          fn({
+            none: mockDb.none,
+            result: mockDb.result,
+          })
+        );
+
+        await auditModel.bulkInsert([
+          { email: 'a@test.com' },
+          { email: 'b@test.com', updated_by: 'explicit-actor' },
+        ]);
+
+        const recordsPassedToInsert = mockPgp.helpers.insert.mock.calls.at(-1)[0];
+        expect(recordsPassedToInsert[0].created_by).toBe('actor-uuid');
+        expect(recordsPassedToInsert[0].updated_by).toBe('actor-uuid');
+        // Explicit updated_by on a single record is respected.
+        expect(recordsPassedToInsert[1].created_by).toBe('actor-uuid');
+        expect(recordsPassedToInsert[1].updated_by).toBe('explicit-actor');
       });
     });
 

--- a/tests/unit/schemaBuilder.test.js
+++ b/tests/unit/schemaBuilder.test.js
@@ -815,7 +815,9 @@ describe('Schema Utilities', () => {
       expect(columnSet).toHaveProperty('insert');
       expect(columnSet).toHaveProperty('update');
       expect(mockExtend).toHaveBeenCalledTimes(2);
-      expect(columnSet.insert.extendedWith).toContain('created_by');
+      expect(columnSet.insert.extendedWith).toEqual(
+        expect.arrayContaining(['created_by', 'updated_by']),
+      );
       expect(columnSet.update.extendedWith).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Summary
- Auto-fill `updated_by` on `insert` and `bulkInsert` so it matches the behavior of `update`/`bulkUpdate`.
- Set `moduleResolution` to `Bundler` in tsconfig.
- Ignore `docs/.vitepress/dist` and `cache` directories in ESLint config.

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] CI green